### PR TITLE
Upgrade 0Chain GoSDK to v1.8.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,6 +95,6 @@ require (
 
 require (
 	github.com/0chain/errors v1.0.3
-	github.com/0chain/gosdk v1.8.16-0.20230427161011-6fb50cdcb352
+	github.com/0chain/gosdk v1.8.16
 	github.com/nats-io/nats-streaming-server v0.21.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -416,8 +416,8 @@ github.com/0chain/common v0.0.6-0.20230127095721-8df4d1d72565/go.mod h1:UyDC8Qyl
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
 github.com/0chain/gorocksdb v0.0.0-20220406081817-640f6b0a3abb/go.mod h1:3i9d+2Osik7apjXERxpAlKxE7SilJKkHoW9Ihdjdfxs=
-github.com/0chain/gosdk v1.8.16-0.20230427161011-6fb50cdcb352 h1:2zPXNeHLBInsKXOJAFWrRzUpDwfZD9HRXGiCNFRKHFw=
-github.com/0chain/gosdk v1.8.16-0.20230427161011-6fb50cdcb352/go.mod h1:z4IjdbQz1dhcM6wdKQWjUYmHoQw3k44QNatb+vdKFAA=
+github.com/0chain/gosdk v1.8.16 h1:nhe4jI/7ZRWDVeannyC0wmv0v3rChiI2bi08PCTRIdA=
+github.com/0chain/gosdk v1.8.16/go.mod h1:z4IjdbQz1dhcM6wdKQWjUYmHoQw3k44QNatb+vdKFAA=
 github.com/Azure/azure-amqp-common-go/v2 v2.1.0/go.mod h1:R8rea+gJRuJR6QxTir/XuEd+YuKoUiazDC/N96FiDEU=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2 h1:6oiIS9yaG6XCCzhgAgKFfIWyo4LLCiDhZot6ltoThhY=


### PR DESCRIPTION
0Chain GoSDK `v1.8.16` is released.
see full changelog on https://github.com/0chain/gosdk/releases/tag/v1.8.16