### PR TITLE
Adding endpoint for multi upload in zs3server code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ go build .
 export MINIO_ROOT_USER=someminiouser
 export MINIO_ROOT_PASSWORD=someminiopassword
 ./minio gateway zcn --configDir /path/to/config/dir
-Note: allocation and configDir both are optional. By default configDir takes ~/.zcn as configDir and if allocation is
- not provided in command then it will look for allocation.txt file in configDir directory.
+Note: allocation and configDir both are optional. By default configDir takes ~/.zcn as configDir and if allocation is not provided in command then it will look for allocation.txt file in configDir directory.
 ```
 
 > If you want to debug on local you might want to build with `-gcflags="all=-N -l"` flag to view all the objects during debugging.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ go mod tidy
 go build .
 export MINIO_ROOT_USER=someminiouser
 export MINIO_ROOT_PASSWORD=someminiopassword
-./zs3server gateway zcn --configDir /path/to/config/dir
-> Note: allocation and configDir both are optional. By default configDir takes ~/.zcn as configDir and if allocation is not provided in command then it will look for allocation.txt file in configDir directory.
+./minio gateway zcn --configDir /path/to/config/dir
+Note: allocation and configDir both are optional. By default configDir takes ~/.zcn as configDir and if allocation is
+ not provided in command then it will look for allocation.txt file in configDir directory.
 ```
+
+> If you want to debug on local you might want to build with `-gcflags="all=-N -l"` flag to view all the objects during debugging.
+
 ## Run using docker 
 
 To build and run minio sevrer component in any machine you will need first to install docker and docker-compose 

--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -303,8 +303,11 @@ func registerAPIRouter(router *mux.Router) {
 			collectAPIStats("putobject", maxClients(gz(httpTraceHdrs(api.PutObjectExtractHandler)))))
 
 		// PutObject
-		router.Methods(http.MethodPut).Path("/{object:.+}").HandlerFunc(
+		router.Methods(http.MethodPut).Path("/{object}").HandlerFunc(
 			collectAPIStats("putobject", maxClients(gz(httpTraceHdrs(api.PutObjectHandler)))))
+		// PutMultipleObjects
+		router.Methods(http.MethodPut).HandlerFunc(
+			collectAPIStats("putmultipleobjects", maxClients(gz(httpTraceHdrs(api.PutMultipleObjectsHandler))))).Queries("multiupload", "true")
 
 		// DeleteObject
 		router.Methods(http.MethodDelete).Path("/{object:.+}").HandlerFunc(

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1861,6 +1861,139 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	}
 }
 
+// PutMultipleObjectsHandler - PUT multiple objects
+// ----------
+// This implementation of the PUT operation adds multiple objects to a bucket.
+
+func (api objectAPIHandlers) PutMultipleObjectsHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := newContext(r, w, "PutMultipleObjects")
+	defer logger.AuditLog(ctx, w, r, mustGetClaimsFromToken(r))
+
+	vars := mux.Vars(r)
+	bucket := vars["bucket"]
+
+	// parse the multipart form to retrieve the file data.
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	objectAPI := api.ObjectAPI()
+	if objectAPI == nil {
+		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrServerNotInitialized), r.URL)
+		return
+	}
+
+	metadata, err := extractMetadata(ctx, r)
+	if err != nil {
+		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL)
+		return
+	}
+
+	// Get the files from the request
+	files := r.MultipartForm.File
+	putErrors := make(map[string]error)
+	rAuthType := getRequestAuthType(r)
+	switch rAuthType {
+	case authTypeStreamingSigned:
+		// Initialize stream signature verifier.
+		_, s3Err := newSignV4ChunkedReader(r)
+		if s3Err != ErrNone {
+			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL)
+			return
+		}
+	case authTypeSignedV2, authTypePresignedV2:
+		s3Err := isReqAuthenticatedV2(r)
+		if s3Err != ErrNone {
+			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL)
+			return
+		}
+
+	case authTypePresigned, authTypeSigned:
+		if s3Err := reqSignatureV4Verify(r, globalSite.Region, serviceS3); s3Err != ErrNone {
+			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL)
+			return
+		}
+	}
+	for objectKey, fileHeaders := range files {
+		// check if put is allowed
+		if s3Err := isPutActionAllowed(ctx, rAuthType, bucket, objectKey, r, iampolicy.PutObjectAction); s3Err != ErrNone {
+			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL)
+			return
+		}
+
+		for _, fileHeader := range fileHeaders {
+			file, err := fileHeader.Open()
+			if err != nil {
+				putErrors[objectKey] = err
+				continue
+			}
+			defer file.Close()
+
+			var (
+				md5hex              = ""
+				sha256hex           = ""
+				reader    io.Reader = file
+				putObject           = objectAPI.PutObject
+			)
+
+			size := fileHeader.Size
+			actualSize := size
+			hashReader, err := hash.NewReader(reader, size, md5hex, sha256hex, actualSize)
+			if err != nil {
+				putErrors[objectKey] = err
+				continue
+			}
+
+			rawReader := hashReader
+			pReader := NewPutObjReader(rawReader)
+
+			var opts ObjectOptions
+			opts, err = putOpts(ctx, r, bucket, objectKey, metadata)
+			if err != nil {
+				putErrors[objectKey] = err
+				continue
+			}
+			objectInfo, err := putObject(ctx, bucket, objectKey, pReader, opts)
+			if err != nil {
+				putErrors[objectKey] = err
+				continue
+			}
+			setPutObjHeaders(w, objectInfo, false)
+		}
+	}
+
+	if len(putErrors) == 0 {
+		writeSuccessResponseHeadersOnly(w)
+	} else {
+		var apiErrors []APIErrorResponse
+		for objectKey, err := range putErrors {
+			apiError := toAPIError(ctx, err)
+			a := APIErrorResponse{
+				Code:       apiError.Code,
+				Message:    apiError.Description,
+				BucketName: bucket,
+				Key:        objectKey,
+				Resource:   bucket + "/" + objectKey,
+				Region:     globalSite.Region,
+				RequestID:  w.Header().Get(xhttp.AmzRequestID),
+				HostID:     globalDeploymentID,
+			}
+			apiErrors = append(apiErrors, a)
+		}
+
+		errorsElem := struct {
+			XMLName xml.Name           `xml:"Errors"`
+			Errors  []APIErrorResponse `xml:"Error"`
+		}{
+			Errors: apiErrors,
+		}
+		encodedErrorResponse := encodeResponse(errorsElem)
+		writeResponse(w, http.StatusInternalServerError, encodedErrorResponse, mimeXML)
+	}
+
+}
+
 // PutObjectExtractHandler - PUT Object extract is an extended API
 // based off from AWS Snowball feature to auto extract compressed
 // stream will be extracted in the same directory it is stored in


### PR DESCRIPTION
## Description
Adding endpoint for multi upload support on zs3server. 
New end point: `PUT` `/:bucket?multiupload=true`
Authorization: `AWS Signature`
Body type: form-data with key as file-name (or object key in bucket) and value as a file object.

## Motivation and Context
We want to support multi file upload in zs3server.

## How to test this PR?
1. Build the project. `go build .`
2. Run the binary. `./minio gateway zcn`
3. Open `localhost:9000` on browser and sign in
4. Add a user with readwrite and writeonly access.
5. Use these creds to call the new endpoint from Postman.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
