### PR TITLE
Fixing multiupload in zs3server by simplifying error handling and removing statuscallbacks

### DIFF
--- a/cmd/erasure-server-pool.go
+++ b/cmd/erasure-server-pool.go
@@ -2151,6 +2151,6 @@ func (z *erasureServerPools) PutMultipleObjects(
 	objects []string,
 	r []*PutObjReader,
 	opts []ObjectOptions,
-) (objInfo []ObjectInfo, err []error) {
-	return nil, []error{NotImplemented{}}
+) (objInfo []ObjectInfo, err error) {
+	return nil, NotImplemented{}
 }

--- a/cmd/fs-v1.go
+++ b/cmd/fs-v1.go
@@ -1470,6 +1470,6 @@ func (fs *FSObjects) PutMultipleObjects(
 	objects []string,
 	r []*PutObjReader,
 	opts []ObjectOptions,
-) (objInfo []ObjectInfo, err []error) {
-	return nil, []error{NotImplemented{}}
+) (objInfo []ObjectInfo, err error) {
+	return nil, NotImplemented{}
 }

--- a/cmd/gateway/azure/gateway-azure.go
+++ b/cmd/gateway/azure/gateway-azure.go
@@ -919,8 +919,8 @@ func (a *azureObjects) PutMultipleObjects(
 	objects []string,
 	r []*minio.PutObjReader,
 	opts []minio.ObjectOptions,
-) (objInfo []minio.ObjectInfo, err []error) {
-	return nil, []error{minio.NotImplemented{}}
+) (objInfo []minio.ObjectInfo, err error) {
+	return nil, minio.NotImplemented{}
 }
 
 // CopyObject - Copies a blob from source container to destination container.

--- a/cmd/gateway/gcs/gateway-gcs.go
+++ b/cmd/gateway/gcs/gateway-gcs.go
@@ -933,8 +933,8 @@ func (l *gcsGateway) PutMultipleObjects(
 	objects []string,
 	r []*minio.PutObjReader,
 	opts []minio.ObjectOptions,
-) (objInfo []minio.ObjectInfo, err []error) {
-	return nil, []error{minio.NotImplemented{}}
+) (objInfo []minio.ObjectInfo, err error) {
+	return nil, minio.NotImplemented{}
 }
 
 // CopyObject - Copies a blob from source container to destination container.

--- a/cmd/gateway/hdfs/gateway-hdfs.go
+++ b/cmd/gateway/hdfs/gateway-hdfs.go
@@ -735,8 +735,8 @@ func (n *hdfsObjects) PutMultipleObjects(
 	objects []string,
 	r []*minio.PutObjReader,
 	opts []minio.ObjectOptions,
-) (objInfo []minio.ObjectInfo, err []error) {
-	return nil, []error{minio.NotImplemented{}}
+) (objInfo []minio.ObjectInfo, err error) {
+	return nil, minio.NotImplemented{}
 }
 
 func (n *hdfsObjects) NewMultipartUpload(ctx context.Context, bucket string, object string, opts minio.ObjectOptions) (uploadID string, err error) {

--- a/cmd/gateway/s3/gateway-s3.go
+++ b/cmd/gateway/s3/gateway-s3.go
@@ -541,8 +541,8 @@ func (l *s3Objects) PutMultipleObjects(
 	objects []string,
 	r []*minio.PutObjReader,
 	opts []minio.ObjectOptions,
-) (objInfo []minio.ObjectInfo, err []error) {
-	return nil, []error{minio.NotImplemented{}}
+) (objInfo []minio.ObjectInfo, err error) {
+	return nil, minio.NotImplemented{}
 }
 
 // CopyObject copies an object from source bucket to a destination bucket.

--- a/cmd/object-api-interface.go
+++ b/cmd/object-api-interface.go
@@ -196,7 +196,7 @@ type ObjectLayer interface {
 	GetObjectNInfo(ctx context.Context, bucket, object string, rs *HTTPRangeSpec, h http.Header, lockType LockType, opts ObjectOptions) (reader *GetObjectReader, err error)
 	GetObjectInfo(ctx context.Context, bucket, object string, opts ObjectOptions) (objInfo ObjectInfo, err error)
 	PutObject(ctx context.Context, bucket, object string, data *PutObjReader, opts ObjectOptions) (objInfo ObjectInfo, err error)
-	PutMultipleObjects(ctx context.Context, bucket string, object []string, data []*PutObjReader, opts []ObjectOptions) (objInfo []ObjectInfo, err []error)
+	PutMultipleObjects(ctx context.Context, bucket string, object []string, data []*PutObjReader, opts []ObjectOptions) (objInfo []ObjectInfo, err error)
 	CopyObject(ctx context.Context, srcBucket, srcObject, destBucket, destObject string, srcInfo ObjectInfo, srcOpts, dstOpts ObjectOptions) (objInfo ObjectInfo, err error)
 	DeleteObject(ctx context.Context, bucket, object string, opts ObjectOptions) (ObjectInfo, error)
 	DeleteObjects(ctx context.Context, bucket string, objects []ObjectToDelete, opts ObjectOptions) ([]DeletedObject, []error)

--- a/go.mod
+++ b/go.mod
@@ -265,5 +265,6 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-//  replace github.com/0chain/gosdk => ../gosdk
+replace github.com/0chain/gosdk => ../gosdk
+
 //replace github.com/herumi/bls-go-binary => github.com/boddumanohar/bls-go-binary v1.30.7

--- a/go.mod
+++ b/go.mod
@@ -265,6 +265,6 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-replace github.com/0chain/gosdk => ../gosdk
+// replace github.com/0chain/gosdk => ../gosdk
 
 //replace github.com/herumi/bls-go-binary => github.com/boddumanohar/bls-go-binary v1.30.7

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,6 @@ github.com/0chain/common v0.0.6-0.20230127095721-8df4d1d72565 h1:z+DtCR8mBsjPnEs
 github.com/0chain/common v0.0.6-0.20230127095721-8df4d1d72565/go.mod h1:UyDC8Qyl5z9lGkCnf9RHJPMektnFX8XtCJZHXCCVj8E=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
-github.com/0chain/gosdk v1.8.17-0.20230727121421-5e33266bb815 h1:g5xPtfboyAn7uCXCi+ODJXidkX4IrU0tSfiSw5CMg04=
-github.com/0chain/gosdk v1.8.17-0.20230727121421-5e33266bb815/go.mod h1:3NKNYzmnMIYqZwwwOgZwMmTW1DT1ZUAmKyVPmYQOiT4=
 github.com/Azure/azure-amqp-common-go/v2 v2.1.0/go.mod h1:R8rea+gJRuJR6QxTir/XuEd+YuKoUiazDC/N96FiDEU=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2 h1:6oiIS9yaG6XCCzhgAgKFfIWyo4LLCiDhZot6ltoThhY=

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/0chain/common v0.0.6-0.20230127095721-8df4d1d72565 h1:z+DtCR8mBsjPnEs
 github.com/0chain/common v0.0.6-0.20230127095721-8df4d1d72565/go.mod h1:UyDC8Qyl5z9lGkCnf9RHJPMektnFX8XtCJZHXCCVj8E=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
+github.com/0chain/gosdk v1.8.17-0.20230727121421-5e33266bb815 h1:g5xPtfboyAn7uCXCi+ODJXidkX4IrU0tSfiSw5CMg04=
+github.com/0chain/gosdk v1.8.17-0.20230727121421-5e33266bb815/go.mod h1:3NKNYzmnMIYqZwwwOgZwMmTW1DT1ZUAmKyVPmYQOiT4=
 github.com/Azure/azure-amqp-common-go/v2 v2.1.0/go.mod h1:R8rea+gJRuJR6QxTir/XuEd+YuKoUiazDC/N96FiDEU=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2 h1:6oiIS9yaG6XCCzhgAgKFfIWyo4LLCiDhZot6ltoThhY=


### PR DESCRIPTION
## Description
Some Refactoring in zs3server multiupload support:
1. Refactored the error to be returned as single error instead of `[]error` for consistency with other APIs.
2. Refactored the PutMultipleObject impl for zcn by removing the callbacks and removing the contentType.

## MinIO client changes to call this end point:
https://github.com/0chain/mc/pull/1

## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
