### PR TITLE
Fixing the nested path upload error

### DIFF
--- a/cmd/api-router.go
+++ b/cmd/api-router.go
@@ -302,12 +302,12 @@ func registerAPIRouter(router *mux.Router) {
 		router.Methods(http.MethodPut).Path("/{object:.+}").HeadersRegexp(xhttp.AmzSnowballExtract, "true").HandlerFunc(
 			collectAPIStats("putobject", maxClients(gz(httpTraceHdrs(api.PutObjectExtractHandler)))))
 
-		// PutObject
-		router.Methods(http.MethodPut).Path("/{object}").HandlerFunc(
-			collectAPIStats("putobject", maxClients(gz(httpTraceHdrs(api.PutObjectHandler)))))
 		// PutMultipleObjects
 		router.Methods(http.MethodPut).HandlerFunc(
 			collectAPIStats("putmultipleobjects", maxClients(gz(httpTraceHdrs(api.PutMultipleObjectsHandler))))).Queries("multiupload", "true")
+		// PutObject
+		router.Methods(http.MethodPut).Path("/{object:.+}").HandlerFunc(
+			collectAPIStats("putobject", maxClients(gz(httpTraceHdrs(api.PutObjectHandler)))))
 
 		// DeleteObject
 		router.Methods(http.MethodDelete).Path("/{object:.+}").HandlerFunc(

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1910,7 +1910,9 @@ func (api objectAPIHandlers) PutMultipleObjectsHandler(w http.ResponseWriter, r 
 
 	// parses the multipart form to retrieve the file data. This parses in 32 MB memory.
 	if err := r.ParseMultipartForm(32 << 20); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		e := fmt.Errorf("for PUT `/:bucket/:object?multiupload=true` api, body should be sent in a "+
+			"multipart/form-data type with key as objectKey and value as file object, error: %s", err.Error())
+		http.Error(w, e.Error(), http.StatusBadRequest)
 		return
 	}
 	var objectKeys []string


### PR DESCRIPTION
## Description
Fixing the nested path upload error (for ex: upload to a location `/root/bucket1/nested1/myfile.txt`) by allowing the path to be part of the url for `PUT` and `Put Multiple`

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
