### PR TITLE
Upgrade 0Chain GoSDK to sprint-1.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	cloud.google.com/go/storage v1.27.0
 	github.com/0chain/errors v1.0.3
-	github.com/0chain/gosdk v1.10.1-0.20231214200656-5a5e14d7d186
+	github.com/0chain/gosdk v1.10.3-0.20231219184536-03f9a47232bb
 	github.com/Azure/azure-pipeline-go v0.2.2
 	github.com/Azure/azure-storage-blob-go v0.10.0
 	github.com/Shopify/sarama v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -62,14 +62,8 @@ github.com/0chain/common v0.0.6-0.20230127095721-8df4d1d72565 h1:z+DtCR8mBsjPnEs
 github.com/0chain/common v0.0.6-0.20230127095721-8df4d1d72565/go.mod h1:UyDC8Qyl5z9lGkCnf9RHJPMektnFX8XtCJZHXCCVj8E=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
-github.com/0chain/gosdk v1.10.1-0.20231214200656-5a5e14d7d186 h1:+BJ+wbnAIgxHB/R6MyekDn3YPObvJe8c0YAfT/WVwqM=
-github.com/0chain/gosdk v1.10.1-0.20231214200656-5a5e14d7d186/go.mod h1:tNJnOciWF1KYaMpTlLBM5BluG8E0GizgN6biUNLwC6o=
-github.com/0chain/gosdk v1.10.1-0.20231217010253-5a1166d9e088 h1:CM1VDEm/dX1Sv0U4ZJ2IEMXWJE+RE0K4eqayW1SBXbI=
-github.com/0chain/gosdk v1.10.1-0.20231217010253-5a1166d9e088/go.mod h1:tNJnOciWF1KYaMpTlLBM5BluG8E0GizgN6biUNLwC6o=
-github.com/0chain/gosdk v1.10.1-0.20231217024042-6fa927150de8 h1:6CxvCuRCn1qR2A2zQ9xPYkrYy0lJbU5clea9LHS70Oc=
-github.com/0chain/gosdk v1.10.1-0.20231217024042-6fa927150de8/go.mod h1:tNJnOciWF1KYaMpTlLBM5BluG8E0GizgN6biUNLwC6o=
-github.com/0chain/gosdk v1.10.1-0.20231217061908-572640e971a5 h1:iFwTLabwjafWpQIMJznRBPBEn0nx1uFC7QlQfy9x6l0=
-github.com/0chain/gosdk v1.10.1-0.20231217061908-572640e971a5/go.mod h1:tNJnOciWF1KYaMpTlLBM5BluG8E0GizgN6biUNLwC6o=
+github.com/0chain/gosdk v1.10.3-0.20231219184536-03f9a47232bb h1:PjgQiGtCwaanWDR0XSD2NxofVCcHAO/0ha5Gk3Jn3WY=
+github.com/0chain/gosdk v1.10.3-0.20231219184536-03f9a47232bb/go.mod h1:DAg/de6vodjEa7CM1/LjElOwntRtNV5lb9rMRaR7fzU=
 github.com/Azure/azure-amqp-common-go/v2 v2.1.0/go.mod h1:R8rea+gJRuJR6QxTir/XuEd+YuKoUiazDC/N96FiDEU=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2 h1:6oiIS9yaG6XCCzhgAgKFfIWyo4LLCiDhZot6ltoThhY=


### PR DESCRIPTION
0Chain GoSDK `sprint-1.11` is released.
see full changelog on https://github.com/0chain/gosdk/releases/tag/sprint-1.11