### PR TITLE
Feat/chunk-upload-2

### DIFF
--- a/cmd/gateway/zcn/dStorage.go
+++ b/cmd/gateway/zcn/dStorage.go
@@ -173,6 +173,7 @@ type downloadStatus struct {
 	reader       *os.File
 	objectInfo   *minio.ObjectInfo
 	downloadTime time.Duration
+	downloaded   int64 // indicates the totay data that has responsed to client
 }
 
 var (

--- a/cmd/gateway/zcn/dStorage.go
+++ b/cmd/gateway/zcn/dStorage.go
@@ -167,8 +167,9 @@ func getSingleRegularRef(alloc *sdk.Allocation, remotePath string) (*sdk.ORef, e
 }
 
 type downloadStatus struct {
-	wg   sync.WaitGroup
-	done bool
+	wg     sync.WaitGroup
+	done   bool
+	reader *os.File
 }
 
 var (
@@ -188,6 +189,7 @@ func getFileReader(ctx context.Context, alloc *sdk.Allocation, remotePath string
 			ds.wg.Wait()
 		} else {
 			mu.Unlock()
+			return ds.reader, localFilePath, nil
 		}
 	} else {
 		ds = &downloadStatus{}
@@ -229,6 +231,7 @@ func getFileReader(ctx context.Context, alloc *sdk.Allocation, remotePath string
 	if err != nil {
 		return nil, "", err
 	}
+	ds.reader = r
 
 	return r, localFilePath, nil
 }

--- a/cmd/gateway/zcn/dStorage.go
+++ b/cmd/gateway/zcn/dStorage.go
@@ -182,14 +182,16 @@ func getFileReader(ctx context.Context, alloc *sdk.Allocation, remotePath string
 
 	mu.Lock()
 	ds, ok := downloads[remotePath]
-	if ok && !ds.done {
-		mu.Unlock()
-		ds.wg.Wait()
-	} else {
-		if !ok {
-			ds = &downloadStatus{}
-			downloads[remotePath] = ds
+	if ok {
+		if !ds.done {
+			mu.Unlock()
+			ds.wg.Wait()
+		} else {
+			mu.Unlock()
 		}
+	} else {
+		ds = &downloadStatus{}
+		downloads[remotePath] = ds
 		ds.wg.Add(1)
 		mu.Unlock()
 

--- a/cmd/gateway/zcn/gateway-zcn.go
+++ b/cmd/gateway/zcn/gateway-zcn.go
@@ -317,11 +317,17 @@ func (zob *zcnObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 			f.Close()
 			os.Remove(localPath)
 
+			var zusDownloadTime time.Duration
 			mu.Lock()
+			ds, ok := downloads[remotePath]
+			if ok {
+				zusDownloadTime = ds.downloadTime
+			}
+
 			delete(downloads, remotePath)
 			mu.Unlock()
 
-			log.Println("^^^^^^^^^^^ remove temp local file: ", localPath)
+			log.Println("^^^^^^^^^^^ remove temp local file: ", localPath, "download from Zus:", zusDownloadTime)
 		}
 	}
 

--- a/cmd/gateway/zcn/gateway-zcn.go
+++ b/cmd/gateway/zcn/gateway-zcn.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -294,6 +295,7 @@ func (zob *zcnObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 	} else {
 		remotePath = filepath.Join(rootPath, bucket, object)
 	}
+	log.Printf("~~~~~~~~~~~~~~~~~~~~~~~~ get object info remotePath: %v\n", remotePath)
 
 	ref, err := getSingleRegularRef(zob.alloc, remotePath)
 	if err != nil {
@@ -302,6 +304,8 @@ func (zob *zcnObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 		}
 		return nil, err
 	}
+
+	log.Println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~get object info, ref: ", ref)
 
 	objectInfo := minio.ObjectInfo{
 		Bucket:  bucket,
@@ -329,8 +333,10 @@ func (zob *zcnObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 	if err != nil {
 		return nil, err
 	}
+	log.Printf("~~~~~~~~~~~~~~~~~~~~~~~~ startOffset: %v, length: %v\n", startOffset, length)
 
 	r := io.NewSectionReader(f, startOffset, length)
+	log.Printf("~~~~~~~~~~~~~~~~~~~~~~~~~~~~section reader : %v\n", r)
 	gr, err = minio.NewGetObjectReaderFromReader(r, objectInfo, opts, fCloser)
 	return
 }
@@ -729,3 +735,7 @@ func (zob *zcnObjects) RevokeShareCredential(ctx context.Context, bucket, object
 	return zob.alloc.RevokeShare(remotePath, clientID)
 }
 */
+
+// ListMultipartUploads(ctx context.Context, bucket, prefix, keyMarker, uploadIDMarker, delimiter string, maxUploads int) (result ListMultipartsInfo, err error)
+// CopyObjectPart(ctx context.Context, srcBucket, srcObject, destBucket, destObject string, uploadID string, partID int,
+// 	startOffset int64, length int64, srcInfo ObjectInfo, srcOpts, dstOpts ObjectOptions) (info PartInfo, err error)

--- a/cmd/gateway/zcn/gateway-zcn.go
+++ b/cmd/gateway/zcn/gateway-zcn.go
@@ -319,6 +319,12 @@ func (zob *zcnObjects) GetObjectNInfo(ctx context.Context, bucket, object string
 	fCloser := func() {
 		f.Close()
 		os.Remove(localPath)
+
+		mu.Lock()
+		delete(downloads, remotePath)
+		mu.Unlock()
+
+		log.Println("^^^^^^^^^^^ remove temp local file: ", localPath)
 	}
 	if err != nil {
 		return nil, err

--- a/cmd/gateway/zcn/multipart.go
+++ b/cmd/gateway/zcn/multipart.go
@@ -170,7 +170,6 @@ func (zob *zcnObjects) newMultiPartUpload(localStorageDir, bucket, object string
 
 					total += cn
 					log.Println("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ uploaded:", total, " new:", cn)
-					close(multiPartFile.doneC) // notify the end of all data uploading
 					return
 				}
 			}

--- a/cmd/gateway/zcn/multipart.go
+++ b/cmd/gateway/zcn/multipart.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/0chain/gosdk/constants"
 	"github.com/0chain/gosdk/core/sys"
@@ -135,6 +136,7 @@ func (zob *zcnObjects) newMultiPartUpload(localStorageDir, bucket, object string
 	go func() {
 		var buf bytes.Buffer
 		var total int64
+		st := time.Now()
 		for {
 			select {
 			case <-multiPartFile.cancelC:
@@ -156,7 +158,6 @@ func (zob *zcnObjects) newMultiPartUpload(localStorageDir, bucket, object string
 					}
 
 					cn, err := io.Copy(multiPartFile.memFile, bytes.NewBuffer(bbuf))
-					// n, err := io.Copy(multiPartFile.memFile, partFile)
 					if err != nil {
 						log.Panicf("upoad part failed, err: %v", err)
 					}
@@ -169,7 +170,7 @@ func (zob *zcnObjects) newMultiPartUpload(localStorageDir, bucket, object string
 					}
 
 					total += cn
-					log.Println("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ uploaded:", total, " new:", cn)
+					log.Println("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ uploaded:", total, " new:", cn, " duration:", time.Since(st))
 					return
 				}
 			}

--- a/cmd/gateway/zcn/multipart.go
+++ b/cmd/gateway/zcn/multipart.go
@@ -384,7 +384,6 @@ func (zob *zcnObjects) constructCompleteObject(bucket, uploadID, object, localSt
 
 		// Break the loop when there are no more parts
 		if _, err := os.Stat(partFilename); os.IsNotExist(err) {
-			close(multiPartFile.dataC) // notify the end of data pusing
 			break
 		}
 

--- a/cmd/gateway/zcn/multipart.go
+++ b/cmd/gateway/zcn/multipart.go
@@ -119,7 +119,7 @@ func (zob *zcnObjects) newMultiPartUpload(localStorageDir, bucket, object string
 		memFile:      memFile,
 		seqPQ:        seqpriorityqueue.NewSeqPriorityQueue(),
 		doneC:        make(chan struct{}),
-		dataC:        make(chan []byte, 10),
+		dataC:        make(chan []byte, 100),
 		readyUploadC: make(chan struct{}),
 		cancelC:      make(chan struct{}),
 	}

--- a/cmd/gateway/zcn/multipart.go
+++ b/cmd/gateway/zcn/multipart.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/0chain/gosdk/constants"
 	"github.com/0chain/gosdk/core/sys"
@@ -30,12 +31,37 @@ var (
 )
 
 type MultiPartFile struct {
-	memFile  *sys.MemChanFile
-	fileSize int64
-	opWg     sync.WaitGroup
-	seqPQ    *seqpriorityqueue.SeqPriorityQueue
-	doneC    chan struct{}
-	dataC    chan []byte
+	memFile       *sys.MemChanFile
+	lock          sync.Mutex
+	fileSize      int64
+	readyToUpload bool
+	opWg          sync.WaitGroup
+	seqPQ         *seqpriorityqueue.SeqPriorityQueue
+	doneC         chan struct{} // indicates that the uploading is done
+	readyUploadC  chan struct{} // indicates we are ready to start the uploading
+	cancelC       chan struct{} // indicate the cancel of the uploading
+	dataC         chan []byte   // data to be uploaded
+}
+
+func (mpf *MultiPartFile) ChunkWriteSize() int64 {
+	return int64(mpf.memFile.ChunkWriteSize)
+}
+
+func (mpf *MultiPartFile) IncreaseFileSize(size int64) {
+	mpf.lock.Lock()
+	ready := mpf.readyToUpload
+	mpf.lock.Unlock()
+	if !ready {
+		atomic.AddInt64(&mpf.fileSize, size)
+	}
+}
+
+func (mpf *MultiPartFile) SetFileSizeAndReadyToUpload(size int64) {
+	mpf.lock.Lock()
+	mpf.fileSize = size
+	mpf.readyToUpload = true
+	mpf.lock.Unlock()
+	close(mpf.readyUploadC)
 }
 
 func (zob *zcnObjects) NewMultipartUpload(ctx context.Context, bucket string, object string, opts minio.ObjectOptions) (uploadID string, err error) {
@@ -59,10 +85,12 @@ func (zob *zcnObjects) newMultiPartUpload(localStorageDir, bucket, object string
 	}
 	log.Println("ChunkReadSize:", memFile.ChunkWriteSize)
 	multiPartFile := &MultiPartFile{
-		memFile: memFile,
-		seqPQ:   seqpriorityqueue.NewSeqPriorityQueue(),
-		doneC:   make(chan struct{}),
-		dataC:   make(chan []byte, 10),
+		memFile:      memFile,
+		seqPQ:        seqpriorityqueue.NewSeqPriorityQueue(),
+		doneC:        make(chan struct{}),
+		dataC:        make(chan []byte, 10),
+		readyUploadC: make(chan struct{}),
+		cancelC:      make(chan struct{}),
 	}
 	FileMap[uploadID] = multiPartFile
 	mapLock.Unlock()
@@ -79,6 +107,10 @@ func (zob *zcnObjects) newMultiPartUpload(localStorageDir, bucket, object string
 		var total int64
 		for {
 			select {
+			case <-multiPartFile.cancelC:
+				log.Println("uploading is canceled, clean up temp dirs")
+				// TODO: clean up temp dirs
+				return
 			case data, ok := <-multiPartFile.dataC:
 				if ok {
 					_, err := buf.Write(data)
@@ -115,38 +147,78 @@ func (zob *zcnObjects) newMultiPartUpload(localStorageDir, bucket, object string
 		}
 	}()
 
-	// go func() {
-	// 	for {
-	// 		partNumber := multiPartFile.seqPQ.Popup()
-	// 		log.Println("==================================== popup part:", partNumber)
+	go func() {
+		select {
+		case <-multiPartFile.readyUploadC:
+		case <-multiPartFile.cancelC:
+			log.Println("uploading is canceled, clean up temp dirs")
+			// TODO: clean up temp dirs
+			return
+		}
+		// Create fileMeta and sdk.OperationRequest
+		fileMeta := sdk.FileMeta{
+			ActualSize: multiPartFile.fileSize, // Need to set the actual size
+			RemoteName: object,
+			RemotePath: "/" + filepath.Join(bucket, object),
+			MimeType:   "application/octet-stream", // can get from request
+		}
+		options := []sdk.ChunkedUploadOption{
+			sdk.WithChunkNumber(250),
+		}
+		operationRequest := sdk.OperationRequest{
+			FileMeta:      fileMeta,
+			FileReader:    multiPartFile.memFile,
+			OperationType: constants.FileOperationInsert,
+			Opts:          options,
+			RemotePath:    fileMeta.RemotePath,
+		}
+		// if its update change operation type
+		multiPartFile.opWg.Add(1)
+		go func() {
+			// run this in background, will block until the data is written to memFile
+			// We should add ctx here to cancel the operation
+			_ = zob.alloc.DoMultiOperation([]sdk.OperationRequest{operationRequest})
+			multiPartFile.opWg.Done()
+		}()
 
-	// 		if partNumber == -1 {
-	// 			close(multiPartFile.dataC)
-	// 			close(multiPartFile.doneC)
-	// 			log.Println("==================================== popup done")
-	// 			return
-	// 		}
+		for {
+			select {
+			case <-multiPartFile.cancelC:
+				log.Println("uploading is canceled, clean up temp dirs")
+				// TODO: clean up temp dirs
+				return
+			default:
+				partNumber := multiPartFile.seqPQ.Popup()
+				log.Println("==================================== popup part:", partNumber)
 
-	// 		partFilename := filepath.Join(localStorageDir, bucket, uploadID, object, fmt.Sprintf("part%d", partNumber))
+				if partNumber == -1 {
+					close(multiPartFile.dataC)
+					close(multiPartFile.doneC)
+					log.Println("==================================== popup done")
+					return
+				}
 
-	// 		func() {
-	// 			// Open the part file for reading
-	// 			partFile, err := os.Open(partFilename)
-	// 			if err != nil {
-	// 				log.Panicf("could not open part file: %v, err: %v", partFilename, err)
-	// 			}
-	// 			defer partFile.Close()
+				partFilename := filepath.Join(localStorageDir, bucket, uploadID, object, fmt.Sprintf("part%d", partNumber))
 
-	// 			data, err := io.ReadAll(partFile)
-	// 			if err != nil {
-	// 				log.Panicf("read part: %v failed, err: %v", partNumber, err)
-	// 			}
+				func() {
+					// Open the part file for reading
+					partFile, err := os.Open(partFilename)
+					if err != nil {
+						log.Panicf("could not open part file: %v, err: %v", partFilename, err)
+					}
+					defer partFile.Close()
 
-	// 			multiPartFile.dataC <- data
-	// 			log.Println("^^^^^^^^^ uploading part:", partNumber, "size:", len(data))
-	// 		}()
-	// 	}
-	// }()
+					data, err := io.ReadAll(partFile)
+					if err != nil {
+						log.Panicf("read part: %v failed, err: %v", partNumber, err)
+					}
+
+					multiPartFile.dataC <- data
+					log.Println("^^^^^^^^^ uploading part:", partNumber, "size:", len(data))
+				}()
+			}
+		}
+	}()
 	return uploadID, nil
 
 }
@@ -159,8 +231,6 @@ func (zob *zcnObjects) PutObjectPart(ctx context.Context, bucket, object, upload
 	partFilename := filepath.Join(localStorageDir, bucket, uploadID, object, fmt.Sprintf("part%d", partID))
 	partETagFilename := partFilename + ".etag"
 
-	// log.Printf("make upload part %v, uploadID: %v, filename: %s", partNumber, uploadID, partFilename)
-	// Create the part file
 	partFile, err := os.Create(partFilename)
 	if err != nil {
 		log.Println(err)
@@ -222,12 +292,15 @@ func (zob *zcnObjects) PutObjectPart(ctx context.Context, bucket, object, upload
 	// Save the ETag to a separate file
 	if err := os.WriteFile(partETagFilename, []byte(eTag), 0644); err != nil {
 		log.Println("error saving ETag file:", err)
-		// http.Error(w, "Error saving ETag", http.StatusInternalServerError)
-		// return
 		return minio.PartInfo{}, fmt.Errorf("error saving ETag file: %v", err)
 	}
 
-	multiPartFile.fileSize += int64(size)
+	if size < multiPartFile.memFile.ChunkWriteSize {
+		// means the last part, calcuate the actual file size: (partNumber - 1) * chunkWriteSize + size
+		multiPartFile.SetFileSizeAndReadyToUpload((int64(partID)-1)*multiPartFile.ChunkWriteSize() + int64(size))
+	} else {
+		multiPartFile.IncreaseFileSize(int64(size))
+	}
 
 	return minio.PartInfo{
 		PartNumber: partID,
@@ -250,35 +323,11 @@ func (zob *zcnObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 		return minio.ObjectInfo{}, fmt.Errorf("uploadID: %v not found", uploadID)
 	}
 
-	log.Println("initial upload, file size:", multiPartFile.fileSize)
-	// Create the bucket directory if it doesn't exist
-	bucketPath := filepath.Join(localStorageDir, bucket, uploadID, object)
-	log.Println("bucketPath:", bucketPath)
-	// Create fileMeta and sdk.OperationRequest
-	fileMeta := sdk.FileMeta{
-		ActualSize: multiPartFile.fileSize, // Need to set the actual size
-		RemoteName: object,
-		RemotePath: "/" + filepath.Join(bucket, object),
-		MimeType:   "application/octet-stream", // can get from request
-	}
-	options := []sdk.ChunkedUploadOption{
-		sdk.WithChunkNumber(250),
-	}
-	operationRequest := sdk.OperationRequest{
-		FileMeta:      fileMeta,
-		FileReader:    multiPartFile.memFile,
-		OperationType: constants.FileOperationInsert,
-		Opts:          options,
-		RemotePath:    fileMeta.RemotePath,
-	}
-	// if its update change operation type
-	multiPartFile.opWg.Add(1)
-	go func() {
-		// run this in background, will block until the data is written to memFile
-		// We should add ctx here to cancel the operation
-		_ = zob.alloc.DoMultiOperation([]sdk.OperationRequest{operationRequest})
-		multiPartFile.opWg.Done()
-	}()
+	// wait for upload to finish
+	multiPartFile.seqPQ.Done()
+	<-multiPartFile.doneC
+	multiPartFile.opWg.Wait()
+	log.Println("finish uploading!!")
 
 	eTag, err := zob.constructCompleteObject(bucket, uploadID, object, localStorageDir, multiPartFile)
 	if err != nil {
@@ -286,13 +335,6 @@ func (zob *zcnObjects) CompleteMultipartUpload(ctx context.Context, bucket, obje
 		return minio.ObjectInfo{}, fmt.Errorf("error constructing complete object: %v", err)
 	}
 
-	// wait for upload to finish
-	// multiPartFile.seqPQ.Done()
-	<-multiPartFile.doneC
-	multiPartFile.opWg.Wait()
-	log.Println("finish uploading!!")
-
-	// TODO: do clean up after all has been uploaded to allocation
 	if err = cleanupPartFilesAndDirs(bucket, uploadID, object, localStorageDir); err != nil {
 		log.Println("Error cleaning up part files and directories:", err)
 		// http.Error(w, "Error cleaning up part files and directories", http.StatusInternalServerError)
@@ -320,22 +362,22 @@ func (zob *zcnObjects) constructCompleteObject(bucket, uploadID, object, localSt
 			break
 		}
 
-		func() {
-			// Open the part file for reading
-			partFile, err := os.Open(partFilename)
-			if err != nil {
-				log.Panicf("could not open part file: %v, err: %v", partFilename, err)
-			}
-			defer partFile.Close()
+		// func() {
+		// 	// Open the part file for reading
+		// 	partFile, err := os.Open(partFilename)
+		// 	if err != nil {
+		// 		log.Panicf("could not open part file: %v, err: %v", partFilename, err)
+		// 	}
+		// 	defer partFile.Close()
 
-			data, err := io.ReadAll(partFile)
-			if err != nil {
-				log.Panicf("read part: %v failed, err: %v", partNumber, err)
-			}
+		// 	data, err := io.ReadAll(partFile)
+		// 	if err != nil {
+		// 		log.Panicf("read part: %v failed, err: %v", partNumber, err)
+		// 	}
 
-			multiPartFile.dataC <- data
-			log.Println("^^^^^^^^^ uploading part:", partNumber, "size:", len(data))
-		}()
+		// 	multiPartFile.dataC <- data
+		// 	log.Println("^^^^^^^^^ uploading part:", partNumber, "size:", len(data))
+		// }()
 
 		// Read the ETag of the part
 		partETagBytes, err := os.ReadFile(partETagFilename)
@@ -433,5 +475,14 @@ func (zob *zcnObjects) ListObjectParts(ctx context.Context, bucket string, objec
 }
 
 func (zob *zcnObjects) AbortMultipartUpload(ctx context.Context, bucket string, object string, uploadID string, opts minio.ObjectOptions) error {
+	log.Println("abort multipart upload, clean up temp dirs")
+	mapLock.Lock()
+	multiPartFile, ok := FileMap[uploadID]
+	mapLock.Unlock()
+	if !ok {
+		log.Printf("uploadID: %v not found\n", uploadID)
+		return fmt.Errorf("abort - uploadID: %v not found", uploadID)
+	}
+	close(multiPartFile.cancelC)
 	return cleanupPartFilesAndDirs(bucket, uploadID, object, localStorageDir)
 }


### PR DESCRIPTION
## Description

- Fix s3 server download for large file with aws cli
- Minor improve for s3 server multipart upload. Aws cli uploads parts in concurrently, therefore the last part could be arrived in advance. The improvement is start the uploading immediately when see the last part. 
- Clean up temp upload dir on abort, means if we cancel the uploading in the middle, all temp files will be removed.

## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated
