### PR TITLE
Upgrade 0Chain GoSDK to sprint-1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.6
 require (
 	cloud.google.com/go/storage v1.27.0
 	github.com/0chain/errors v1.0.3
-	github.com/0chain/gosdk v1.16.0-RC1
+	github.com/0chain/gosdk v1.16.0-RC7.0.20240709185813-50d810b670eb
 	github.com/Azure/azure-pipeline-go v0.2.2
 	github.com/Azure/azure-storage-blob-go v0.10.0
 	github.com/Shopify/sarama v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/0chain/common v0.0.6-0.20230127095721-8df4d1d72565 h1:z+DtCR8mBsjPnEs
 github.com/0chain/common v0.0.6-0.20230127095721-8df4d1d72565/go.mod h1:UyDC8Qyl5z9lGkCnf9RHJPMektnFX8XtCJZHXCCVj8E=
 github.com/0chain/errors v1.0.3 h1:QQZPFxTfnMcRdt32DXbzRQIfGWmBsKoEdszKQDb0rRM=
 github.com/0chain/errors v1.0.3/go.mod h1:xymD6nVgrbgttWwkpSCfLLEJbFO6iHGQwk/yeSuYkIc=
-github.com/0chain/gosdk v1.16.0-RC1 h1:X/tRIwEQP86boEqH+L3f67QsMbzy2I9MR2jEf+JopTA=
-github.com/0chain/gosdk v1.16.0-RC1/go.mod h1:y7Ucdmv40VltqulZnncMNjNQ4piX5Dta5ujNmPmXnxg=
+github.com/0chain/gosdk v1.16.0-RC7.0.20240709185813-50d810b670eb h1:YQCuS9hQSyt+vGvXN3Nb480h9rnnL7M2bTi9Je80Aoo=
+github.com/0chain/gosdk v1.16.0-RC7.0.20240709185813-50d810b670eb/go.mod h1:y7Ucdmv40VltqulZnncMNjNQ4piX5Dta5ujNmPmXnxg=
 github.com/Azure/azure-amqp-common-go/v2 v2.1.0/go.mod h1:R8rea+gJRuJR6QxTir/XuEd+YuKoUiazDC/N96FiDEU=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2 h1:6oiIS9yaG6XCCzhgAgKFfIWyo4LLCiDhZot6ltoThhY=


### PR DESCRIPTION
0Chain GoSDK `sprint-1.16` is released.
see full changelog on https://github.com/0chain/gosdk/releases/tag/sprint-1.16