### PR TITLE
Updated zs3server.json to work with 72 core zs3server

### DIFF
--- a/zs3server.json
+++ b/zs3server.json
@@ -1,10 +1,10 @@
 {
   "encrypt": false,
   "compress": false,
-  "max_batch_size": 25,
-  "batch_wait_time": 500,
-  "batch_workers": 5,
-  "upload_workers": 4,
-  "download_workers": 6,
-  "max_concurrent_requests": 150
+  "max_batch_size": 40,
+  "batch_wait_time": 70,
+  "batch_workers": 72,
+  "upload_workers": 72,
+  "download_workers": 72,
+  "max_concurrent_requests": 400
 }


### PR DESCRIPTION
## Description
Updating default s3server.json file to work with a 72core zs3server

## Motivation and Context
Set this as the default parameters so it is easier for the one-click solution setup. This works for a zs3server that has 72 cores. Also optimized batch size and wait time to ensure every batch is filled before getting flushed (reduce latency).

## How to test this PR?
Run this with the Zs3 warp test : https://docs.zus.network/zus-devops/zus-network-testing/performance-test/zs3server-warp-benchmark-testing

## Types of changes
- [ ] Optimization (provides optimized performance for the 72 core zs3server setup)

## Checklist:
- [ ] Zs3server file updated
